### PR TITLE
Removed truncate option

### DIFF
--- a/frontEndFunctions.m
+++ b/frontEndFunctions.m
@@ -533,7 +533,7 @@ methods (Static)
       data    = h.data;    % get user data from gui handle
 
       % open smr, txt, or mat file
-      str = sprintf('\tWarning! The path to open a faile is hardcoded (It won''t crash, this is informative. Check ''frontEndFunctions.load_voltage'').\n');
+      str = sprintf('\tWarning! The path to open a file is hardcoded (It won''t crash, this is informative. Check ''frontEndFunctions.load_voltage'').\n');
       printMessage('off', 'SystemCommands', str);
       try
         temp_dir = data.last_dir;

--- a/openVoltageFile.m
+++ b/openVoltageFile.m
@@ -94,19 +94,20 @@ function [data, success] = openVoltageFile(data, varargin)
          SETdata.dt      = time(2) - time(1);
          SETdata.params  = [];
       end
-         
-      if strcmpi(SETdata.type, 'voltage') && length(time)>1e4
-         if ~isBatch
-            response = userConfirmation('Truncate voltage timeseries?','Voltage length');
-            switch lower(response)
-              case 'yes'
-                 [newdata, time] = truncateVoltage(newdata, time);
-              case 'no'
-            end
-         end
-         SETdata.data = newdata; 
-         SETdata.time = time;
-      end
+      
+      %% Next few lines show a popup to truncate the time series. Commented because it is not in use.
+%       if strcmpi(SETdata.type, 'voltage') && length(time)>1e4
+%          if ~isBatch
+%             response = userConfirmation('Truncate voltage timeseries?','Voltage length');
+%             switch lower(response)
+%               case 'yes'
+%                  [newdata, time] = truncateVoltage(newdata, time);
+%               case 'no'
+%             end
+%          end
+%          SETdata.data = newdata; 
+%          SETdata.time = time;
+%       end
 
       %% TO DO: allow saving & loading of voltage from gui with extra info
       try

--- a/rescaleVoltage.m
+++ b/rescaleVoltage.m
@@ -151,7 +151,15 @@ function [vrescale, Rest_vec, tpeak_vec, params] = rescaleVoltageRecursive(tseri
    % Initialise the rest of the values
    [vspike,  tspike]     = initSpikes(time, dt, peakfn(v), noisesig*voltoutlier, peakfn, glitchthresh * noisesig, jumpahead, debug); % identify initial spikes
    [Rest, Rcoeff, Rmu, Rstd, Rcov] = initRegress(tspike-tspike(1), vspike, lambda, npoles, nzeros, debug); % est init resistance
-   a = Rcoeff(2:npoles+1); b = [Rcoeff(1); Rcoeff(npoles+2:end)'];
+   a = Rcoeff(2:npoles+1); 
+   % Make sure b ends up a column vector and no concatenation errors due to
+   % shape misatch
+   size_Rcoeff = size(Rcoeff);
+   if size_Rcoeff(2) == 1
+       b = [Rcoeff(1); Rcoeff(npoles+2:end)];
+   else
+       b = [Rcoeff(1); Rcoeff(npoles+2:end)'];
+   end
    Rinit    = Rest(end); % The initial estimate is what might be causing the initial change in rescalings %TODO
    Rcovprev = Rcov;
    vmu      = mean( vspike );


### PR DESCRIPTION
+ Removed the "truncate" popup after loading a new voltage. It was never used and was annoying. Considering adding it as an option in the context menu. Would have to implement.

+ Previous pull request still had some issues with the bug. Added a sanity check to make sure the vector b is always a column and to avoid dimension mismatch when concatenating Rcoeff.